### PR TITLE
Should fix boxes support with tesseract 3.0

### DIFF
--- a/tesseract.py
+++ b/tesseract.py
@@ -63,12 +63,12 @@ def run_tesseract(input_filename, output_filename_base, lang=None, boxes=False):
 
     command = [tesseract_cmd, input_filename, output_filename_base]
     
-    if boxes:
-        command += ['batch.nochop', 'makebox']
-    
     if lang is not None:
         command += ['-l', lang]
 
+    if boxes:
+        command += ['batch.nochop', 'makebox']
+    
     proc = subprocess.Popen(command,
             stderr=subprocess.PIPE)
     return (proc.wait(), proc.stderr.read())
@@ -120,7 +120,10 @@ def image_to_string(image, lang=None, boxes=False):
 
     input_file_name = '%s.bmp' % tempnam()
     output_file_name_base = tempnam()
-    output_file_name = '%s.txt' % output_file_name_base
+    if not boxes:
+        output_file_name = '%s.txt' % output_file_name_base
+    else:
+        output_file_name = '%s.box' % output_file_name_base
     try:
         image.save(input_file_name)
         status, error_string = run_tesseract(input_file_name,


### PR DESCRIPTION
It seems that when you want to use boxes with tesseract 3.0, argument order matters. Also the output file doesn't have the same extension.

Signed-off-by: Jerome Flesch jflesch@gmail.com
