### PR TITLE
Fixed ImportError when using Pillow

### DIFF
--- a/pytesseract/pytesseract.py
+++ b/pytesseract/pytesseract.py
@@ -44,7 +44,10 @@ http://wiki.github.com/hoffstaetter/python-tesseract
 # CHANGE THIS IF TESSERACT IS NOT IN YOUR PATH, OR IS NAMED DIFFERENTLY
 tesseract_cmd = 'tesseract'
 
-import Image
+try:
+    import Image
+except ImportError:
+    from PIL import Image
 import StringIO
 import subprocess
 import sys


### PR DESCRIPTION
PIL's successor, Pillow, only allows importing `Image` by using:

```
from PIL import Image
```

rather than:

```
import Image
```

This pull request makes python-tesseract compatible with Pillow. Note that `from PIL import Image` also works for PIL. It's just that PIL allowed both ways of importing wheres Pillow only allows `from PIL import Image`.
