### PR TITLE
Fix docstring in pytesseract.py to match README

### DIFF
--- a/pytesseract/pytesseract.py
+++ b/pytesseract/pytesseract.py
@@ -19,7 +19,7 @@ From the shell:
  $ ./tesseract.py -l fra test-european.jpg  # recognizes french text
 In python:
  > import Image
- > from tesseract import image_to_string
+ > from pytesseract import image_to_string
  > print image_to_string(Image.open('test.png'))
  > print image_to_string(Image.open('test-european.jpg'), lang='fra')
 


### PR DESCRIPTION
Was `from tesseract import image_to_string`; should be `from pytesseract`.
