### PR TITLE
Allows tesseract to implement config options

### DIFF
--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -62,6 +62,7 @@ import StringIO
 import subprocess
 import sys
 import os
+import shlex
 
 __all__ = ['image_to_string']
 
@@ -82,7 +83,7 @@ def run_tesseract(input_filename, output_filename_base, lang=None, boxes=False, 
         command += ['batch.nochop', 'makebox']
         
     if config:
-        command += [config]
+        command += shlex.split(config)
     
     proc = subprocess.Popen(command,
             stderr=subprocess.PIPE)


### PR DESCRIPTION
The config argument for run_tesseract() doesn't currently work properly. It gives tesseract a single string, which tesseract can't recognize, and so the config options aren't implemented. A simple shlex.split() fixes that by splitting the config argument into individual strings and putting them to a list. I.e., run_tesseract(foo.png, bar, config="-psm 8 nobatch letters") will pass ["-psm", "8", "nobatch", "letters"] to tesseract, instead of ["-psm 8 nobatch letters"].

Please consider a commit, or another solution to this problem.