### PR TITLE
Decode tesseract's output as UTF-8

### DIFF
--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -162,9 +162,9 @@ def image_to_string(image, lang=None, boxes=False, config=None):
         if status:
             errors = get_errors(error_string)
             raise TesseractError(status, errors)
-        f = open(output_file_name)
+        f = open(output_file_name, 'rb')
         try:
-            return f.read().strip()
+            return f.read().decode('utf-8').strip()
         finally:
             f.close()
     finally:


### PR DESCRIPTION
If Tesseract produces non-ascii output, pytesseract blows up when trying
to read the output file.

This commit forces pytesseract to treat Tesseract's output 1) as a binary file
type and 2) as UTF-8 encoded.

```
  File ".../vault/vault/libs/ocr_document/ocr_document.py", line 80, in ocr_segment
    extracted_text = pytesseract.image_to_string(cropped_pil_image)
  File ".../venv/lib/python3.4/site-packages/pytesseract/pytesseract.py", line 167, in image_to_string
    return f.read().strip()
  File ".../venv/lib/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 21: ordinal not in range(128)
```
