### PR TITLE
added support for 'hocr' config

### DIFF
--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -35,21 +35,21 @@ Prerequisites:
   isn't the case, for example because tesseract isn't in your PATH, you will
   have to change the "tesseract_cmd" variable at the top of 'tesseract.py'.
   Under Debian/Ubuntu you can use the package "tesseract-ocr".
-  
-Installing via pip:   
-See the [pytesseract package page](https://pypi.python.org/pypi/pytesseract)     
-$> sudo pip install pytesseract   
 
-Installing from source:   
-$> git clone git@github.com:madmaze/pytesseract.git   
-$> sudo python setup.py install    
+Installing via pip:
+See the [pytesseract package page](https://pypi.python.org/pypi/pytesseract)
+$> sudo pip install pytesseract
+
+Installing from source:
+$> git clone git@github.com:madmaze/pytesseract.git
+$> sudo python setup.py install
 
 
 LICENSE:
 Python-tesseract is released under the GPL v3.
 
 CONTRIBUTERS:
-- Originally written by [Samuel Hoffstaetter](https://github.com/hoffstaetter) 
+- Originally written by [Samuel Hoffstaetter](https://github.com/hoffstaetter)
 - [Juarez Bochi](https://github.com/jbochi)
 - [Matthias Lee](https://github.com/madmaze)
 - [Lars Kistner](https://github.com/Sr4l)
@@ -58,6 +58,9 @@ CONTRIBUTERS:
 
 # CHANGE THIS IF TESSERACT IS NOT IN YOUR PATH, OR IS NAMED DIFFERENTLY
 tesseract_cmd = 'tesseract'
+config_to_out_file_extension = {
+    'hocr': 'hocr'
+}
 
 try:
     import Image
@@ -75,21 +78,21 @@ def run_tesseract(input_filename, output_filename_base, lang=None, boxes=False, 
     '''
     runs the command:
         `tesseract_cmd` `input_filename` `output_filename_base`
-    
+
     returns the exit status of tesseract, as well as tesseract's stderr output
 
     '''
     command = [tesseract_cmd, input_filename, output_filename_base]
-    
+
     if lang is not None:
         command += ['-l', lang]
 
     if boxes:
         command += ['batch.nochop', 'makebox']
-        
+
     if config:
         command += shlex.split(config)
-    
+
     proc = subprocess.Popen(command,
             stderr=subprocess.PIPE)
     return (proc.wait(), proc.stderr.read())
@@ -130,9 +133,9 @@ def image_to_string(image, lang=None, boxes=False, config=None):
     Runs tesseract on the specified image. First, the image is written to disk,
     and then the tesseract command is run on the image. Resseract's result is
     read, and the temporary files are erased.
-    
+
     also supports boxes and config.
-    
+
     if boxes=True
         "batch.nochop makebox" gets added to the tesseract call
     if config is set, the config gets appended to the command.
@@ -145,13 +148,13 @@ def image_to_string(image, lang=None, boxes=False, config=None):
         # Kind of a hack, should fix in the future some time.
         r, g, b, a = image.split()
         image = Image.merge("RGB", (r, g, b))
-    
+
     input_file_name = '%s.bmp' % tempnam()
     output_file_name_base = tempnam()
-    if not boxes:
-        output_file_name = '%s.txt' % output_file_name_base
-    else:
-        output_file_name = '%s.box' % output_file_name_base
+
+    fileextension = 'box' if boxes else config_to_out_file_extension.get(config, 'txt')
+    output_file_name = '%s.%s' % (output_file_name_base, fileextension)
+
     try:
         image.save(input_file_name)
         status, error_string = run_tesseract(input_file_name,


### PR DESCRIPTION
The issue with running with `config='hocr'` was that tesseract saves files with 'hocr' and not `txt` extension, so in that case you get following traceback:

```
Traceback (most recent call last):
  File "bin/xxx", line 32, in <module>
    sys.exit(xxx.cli())
  File "/home/.../__init__.py", line 55, in cli
    main(paths=arguments['<path>'], output_dir=arguments['--output'], visitor=visitor)
  File "/home/.../__init__.py", line 42, in main
    pipe.run(data={'filename': file_path})
  File "/home/.../pipeline.py", line 42, in run
    step_data = pipe.call(**{k: self.pipe_data[k] for k in pipe.args})
  File "/home/.../pipes/ocr.py", line 11, in get_text
    text = pytesseract.image_to_string(image, lang='eng', config='hocr')
  File "/home/.../pytesseract-0.1.6-py2.7.egg/pytesseract/pytesseract.py", line 165, in image_to_string
    f = open(output_file_name)
IOError: [Errno 2] No such file or directory: '/tmp/tess_a1lMV9.txt'
```
