### PR TITLE
Dev

### DIFF
--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -92,7 +92,10 @@ def run_tesseract(input_filename, output_filename_base, lang=None, boxes=False, 
     
     proc = subprocess.Popen(command,
             stderr=subprocess.PIPE)
-    return (proc.wait(), proc.stderr.read())
+    status = proc.wait()
+    error_string = proc.stderr.read()
+    proc.stderr.close()
+    return (status, error_string)
 
 def cleanup(filename):
     ''' tries to remove the given filename. Ignores non-existent files '''

--- a/src/run_tests.py
+++ b/src/run_tests.py
@@ -1,0 +1,25 @@
+'''
+Created on Apr 24, 2015
+
+@author: madmaze
+'''
+import unittest
+import pytesseract as pyt
+import Image
+
+class TestStringMethods(unittest.TestCase):
+
+    def test_image_to_string_basic(self):
+        im = Image.open("test.png")
+        res = pyt.image_to_string(im)
+        self.assertEqual(res, ('This is a lot of 12 point text to test the\n' + 
+                               'ocr code and see if it works on all types\n' +
+                               'of file format.\n\nThe quick brown dog jumped over the\n' +
+                               'lazy fox. The quick brown dog jumped\n' +
+                               'over the lazy fox. The quick brown dog\n' +
+                               'jumped over the lazy fox. The quick\n' +
+                               'brown dog jumped over the lazy fox.'))
+
+    
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add UTF-8 encoding when opening parsed image text file

Currently in pytesseract.py:L165:
`f = open(output_file_name)`
should be replaced with
`f = open(output_file_name, encoding='utf-8')`
to enhance compatibility with special characters, e.g. images that was recognized as special characters.
