### PR TITLE
evaluate images as np array for cv2 compatibility

### DIFF
--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -16,7 +16,6 @@ import subprocess
 import tempfile
 import shlex
 import numpy as np
-import cv2
 
 
 # CHANGE THIS IF TESSERACT IS NOT IN YOUR PATH, OR IS NAMED DIFFERENTLY

--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -16,6 +16,7 @@ import subprocess
 import tempfile
 import shlex
 import numpy as np
+import cv2
 
 
 # CHANGE THIS IF TESSERACT IS NOT IN YOUR PATH, OR IS NAMED DIFFERENTLY
@@ -91,6 +92,10 @@ class TesseractError(Exception):
         self.message = message
         self.args = (status, message)
 
+def save(img, img_filename):
+    if type(img) is np.ndarray:
+        img = Image.fromarray(img)
+    img.save(img_filename)
 
 def image_to_string(image, lang=None, boxes=False, config=None, nice=0):
     '''
@@ -123,7 +128,7 @@ def image_to_string(image, lang=None, boxes=False, config=None, nice=0):
     else:
         output_file_name = '%s.box' % output_file_name_base
     try:
-        image.save(input_file_name)
+        save(image, input_file_name)
         status, error_string = run_tesseract(input_file_name,
                                              output_file_name_base,
                                              lang=lang,

--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -15,6 +15,7 @@ import sys
 import subprocess
 import tempfile
 import shlex
+import numpy as np
 
 
 # CHANGE THIS IF TESSERACT IS NOT IN YOUR PATH, OR IS NAMED DIFFERENTLY
@@ -109,7 +110,7 @@ def image_to_string(image, lang=None, boxes=False, config=None, nice=0):
         doesn't work on windows. Nice (unix) adjusts the niceness of the process.
     '''
 
-    if len(image.split()) == 4:
+    if np.array(image).shape[2] == 4:
         # In case we have 4 channels, lets discard the Alpha.
         # Kind of a hack, should fix in the future some time.
         r, g, b, a = image.split()


### PR DESCRIPTION
I'd like to be able to pass opencv images into pytesseract, but openCV images do not have the split() method since they're interfaced with as a numpy array.

I know this is a hacky workaround, but it looks like you're planning on fully overhauling that section of code at some point anyway.

This is tested to work with current PIL Image implementation and also allows for cv2.imread() images.