### PR TITLE
Added verbose option that returns detailed output from tesseract run

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,7 @@ USAGE
 -----
 
 ### Quickstart ###
+
 .. code-block:: python
 
     try:
@@ -36,7 +37,7 @@ USAGE
     
     # Get verbose data including boxes, confidences, line and page numbers
     print(pytesseract.image_to_data(Image.open('test.png')))
- ```
+
  
 ### Functions ###
 

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Add the following config, if you have tessdata error like: "Error opening data f
 
 * **image_to_boxes** Returns string output containing recognized characters and their box boundaries
 
-* **image_to_data** Returns string output containing box boundaries, confidences, and other information. Requires Tesseract 3.05+ (see <a href="https://github.com/tesseract-ocr/tesseract/wiki/Command-Line-Usage#tsv-output-currently-available-in-305-dev-in-master-branch-on-github">Tesseract TSV documentation</a> for more information
+* **image_to_data** Returns string output containing box boundaries, confidences, and other information. Requires Tesseract 3.05+. See `Tesseract TSV documentation <https://github.com/tesseract-ocr/tesseract/wiki/Command-Line-Usage#tsv-output-currently-available-in-305-dev-in-master-branch-on-github>`_ for more information: 
 
 **Parameters**
 
@@ -83,7 +83,7 @@ Add the following config, if you have tessdata error like: "Error opening data f
 
 * **nice** Boolean, modifies the processor priority for the Tesseract run. Not supported on Windows. Nice adjusts the niceness of unix-like processes.
 
-* **dict_output** Boolean, if ``True`` will return dictionary containing headers pointing to list columns of data. Used for ```image_to_boxes``` and ```image_to_data``` only
+* **dict_output** Boolean, if ``True`` will return dictionary containing headers pointing to list columns of data. Used for ``image_to_boxes`` and ``image_to_data`` only
 
 
 INSTALLATION

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,4 @@
-Python Tesseract
-================
+# Python Tesseract
 
 Python-tesseract is an optical character recognition (OCR) tool for python.
 That is, it will recognize and "read" the text embedded in images.
@@ -10,15 +9,14 @@ supported by the Python Imaging Library, including jpeg, png, gif, bmp, tiff,
 and others, whereas tesseract-ocr by default only supports tiff and bmp.
 Additionally, if used as a script, Python-tesseract will print the recognized
 text instead of writing it to a file.
-.. _Google's Tesseract-OCR Engine: https://github.com/tesseract-ocr/tesseract
+Google's Tesseract-OCR Engine: https://github.com/tesseract-ocr/tesseract
 
-USAGE
------
+## USAGE
+
 
 ### Quickstart
 
-.. code-block:: python
-
+```
     try:
         import Image
     except ImportError:
@@ -37,7 +35,7 @@ USAGE
     
     # Get verbose data including boxes, confidences, line and page numbers
     print(pytesseract.image_to_data(Image.open('test.png')))
-
+```
  
 ### Functions
 
@@ -52,7 +50,9 @@ Returns string output containing box boundaries, confidences, and other informat
 
 ### Parameters
 
-`` def image_to_data(image, lang=None, config='', nice=0, format='dict') ``
+```
+def image_to_data(image, lang=None, config='', nice=0, format='dict')
+```
 
 **image**
 PIL image file for the image to be processed by Tesseract
@@ -69,7 +69,7 @@ Modifies the processor priority for the Tesseract run. Not supported on Windows.
  
 Support for OpenCV image/NumPy array objects
 
-.. code-block:: python
+```python
 
     import cv2
 
@@ -77,17 +77,17 @@ Support for OpenCV image/NumPy array objects
     print(pytesseract.image_to_string(img))
     # OR explicit beforehand converting
     print(pytesseract.image_to_string(Image.fromarray(img))
-
+```
 Add the following config, if you have tessdata error like: "Error opening data file..."
 
-.. code-block:: python
+```python
 
     tessdata_dir_config = '--tessdata-dir "<replace_with_your_tessdata_dir_path>"'
     # Example config: '--tessdata-dir "C:\\Program Files (x86)\\Tesseract-OCR\\tessdata"'
     # It's important to add double quotes around the dir path.
 
     pytesseract.image_to_string(image, lang='chi_sim', config=tessdata_dir_config)
-    
+``` 
 
 
 INSTALLATION

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,8 @@ text instead of writing it to a file.
 
 USAGE
 -----
+
+### Quickstart ###
 .. code-block:: python
 
     try:
@@ -34,7 +36,36 @@ USAGE
     
     # Get verbose data including boxes, confidences, line and page numbers
     print(pytesseract.image_to_data(Image.open('test.png')))
-    
+ ```
+ 
+### Functions ###
+
+**image_to_string**
+Returns the result of a Tesseract OCR run on the image to string
+
+**image_to_boxes**
+Returns string output containing recognized characters and their box boundaries
+
+**image_to_data**
+Returns string output containing box boundaries, confidences, and other information. Requires Tesseract 3.05+ (see <a href="https://github.com/tesseract-ocr/tesseract/wiki/Command-Line-Usage#tsv-output-currently-available-in-305-dev-in-master-branch-on-github">Tesseract TSV documentation</a> for more information
+
+### Parameters ###
+
+``` def image_to_data(image, lang=None, config='', nice=0, format='dict') ```
+
+**image**
+PIL image file for the image to be processed by Tesseract
+
+**lang**
+Language code
+
+**config**
+Any additional configurations, ex: ```config="-psm 6"```
+
+**nice**
+Modifies the processor priority for the Tesseract run. Not supported on Windows. Nice adjusts the niceness of unix-like processes.
+
+ 
 Support for OpenCV image/NumPy array objects
 
 .. code-block:: python
@@ -55,6 +86,8 @@ Add the following config, if you have tessdata error like: "Error opening data f
     # It's important to add double quotes around the dir path.
 
     pytesseract.image_to_string(image, lang='chi_sim', config=tessdata_dir_config)
+    
+
 
 INSTALLATION
 ------------

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,10 @@ USAGE
     # Include the above line, if you don't have tesseract executable in your PATH
     # Example tesseract_cmd: 'C:\\Program Files (x86)\\Tesseract-OCR\\tesseract'
 
+    # Simple image to string
     print(pytesseract.image_to_string(Image.open('test.png')))
+    
+    # French text image to string
     print(pytesseract.image_to_string(Image.open('test-european.jpg'), lang='fra'))
     
     # Get bounding box estimates
@@ -74,11 +77,13 @@ Add the following config, if you have tessdata error like: "Error opening data f
 
 * **image** PIL image file for the image to be processed by Tesseract
 
-* **lang** Language code
+* **lang** Language code string
 
-* **config** Any additional configurations, ex: ```config="-psm 6"```
+* **config** Any additional configurations as a string, ex: ```config="-psm 6"```
 
-* **nice** Modifies the processor priority for the Tesseract run. Not supported on Windows. Nice adjusts the niceness of unix-like processes.
+* **nice** Boolean, modifies the processor priority for the Tesseract run. Not supported on Windows. Nice adjusts the niceness of unix-like processes.
+
+* **dict_output** Boolean, if ``True`` will return dictionary containing headers pointing to list columns of data. Used for ```image_to_boxes``` and ```image_to_data``` only
 
 
 INSTALLATION

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ text instead of writing it to a file.
 USAGE
 -----
 
-### Quickstart ###
+### Quickstart
 
 .. code-block:: python
 
@@ -39,7 +39,7 @@ USAGE
     print(pytesseract.image_to_data(Image.open('test.png')))
 
  
-### Functions ###
+### Functions
 
 **image_to_string**
 Returns the result of a Tesseract OCR run on the image to string
@@ -50,9 +50,9 @@ Returns string output containing recognized characters and their box boundaries
 **image_to_data**
 Returns string output containing box boundaries, confidences, and other information. Requires Tesseract 3.05+ (see <a href="https://github.com/tesseract-ocr/tesseract/wiki/Command-Line-Usage#tsv-output-currently-available-in-305-dev-in-master-branch-on-github">Tesseract TSV documentation</a> for more information
 
-### Parameters ###
+### Parameters
 
-``` def image_to_data(image, lang=None, config='', nice=0, format='dict') ```
+`` def image_to_data(image, lang=None, config='', nice=0, format='dict') ``
 
 **image**
 PIL image file for the image to be processed by Tesseract

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,5 @@
-# Python Tesseract
+Python Tesseract
+================
 
 Python-tesseract is an optical character recognition (OCR) tool for python.
 That is, it will recognize and "read" the text embedded in images.
@@ -9,14 +10,15 @@ supported by the Python Imaging Library, including jpeg, png, gif, bmp, tiff,
 and others, whereas tesseract-ocr by default only supports tiff and bmp.
 Additionally, if used as a script, Python-tesseract will print the recognized
 text instead of writing it to a file.
-Google's Tesseract-OCR Engine: https://github.com/tesseract-ocr/tesseract
+.. _Google's Tesseract-OCR Engine: https://github.com/tesseract-ocr/tesseract
 
-## USAGE
+USAGE
+-----
 
+**Quickstart**
 
-### Quickstart
+.. code-block:: python
 
-```
     try:
         import Image
     except ImportError:
@@ -35,41 +37,10 @@ Google's Tesseract-OCR Engine: https://github.com/tesseract-ocr/tesseract
     
     # Get verbose data including boxes, confidences, line and page numbers
     print(pytesseract.image_to_data(Image.open('test.png')))
-```
- 
-### Functions
-
-**image_to_string**
-Returns the result of a Tesseract OCR run on the image to string
-
-**image_to_boxes**
-Returns string output containing recognized characters and their box boundaries
-
-**image_to_data**
-Returns string output containing box boundaries, confidences, and other information. Requires Tesseract 3.05+ (see <a href="https://github.com/tesseract-ocr/tesseract/wiki/Command-Line-Usage#tsv-output-currently-available-in-305-dev-in-master-branch-on-github">Tesseract TSV documentation</a> for more information
-
-### Parameters
-
-```
-def image_to_data(image, lang=None, config='', nice=0, format='dict')
-```
-
-**image**
-PIL image file for the image to be processed by Tesseract
-
-**lang**
-Language code
-
-**config**
-Any additional configurations, ex: ```config="-psm 6"```
-
-**nice**
-Modifies the processor priority for the Tesseract run. Not supported on Windows. Nice adjusts the niceness of unix-like processes.
-
- 
+    
 Support for OpenCV image/NumPy array objects
 
-```python
+.. code-block:: python
 
     import cv2
 
@@ -77,17 +48,37 @@ Support for OpenCV image/NumPy array objects
     print(pytesseract.image_to_string(img))
     # OR explicit beforehand converting
     print(pytesseract.image_to_string(Image.fromarray(img))
-```
+
 Add the following config, if you have tessdata error like: "Error opening data file..."
 
-```python
+.. code-block:: python
 
     tessdata_dir_config = '--tessdata-dir "<replace_with_your_tessdata_dir_path>"'
     # Example config: '--tessdata-dir "C:\\Program Files (x86)\\Tesseract-OCR\\tessdata"'
     # It's important to add double quotes around the dir path.
 
     pytesseract.image_to_string(image, lang='chi_sim', config=tessdata_dir_config)
-``` 
+
+
+**Functions**
+
+* **image_to_string** Returns the result of a Tesseract OCR run on the image to string
+
+* **image_to_boxes** Returns string output containing recognized characters and their box boundaries
+
+* **image_to_data** Returns string output containing box boundaries, confidences, and other information. Requires Tesseract 3.05+ (see <a href="https://github.com/tesseract-ocr/tesseract/wiki/Command-Line-Usage#tsv-output-currently-available-in-305-dev-in-master-branch-on-github">Tesseract TSV documentation</a> for more information
+
+### Parameters
+
+``def image_to_data(image, lang=None, config='', nice=0, format='dict')``
+
+* **image** PIL image file for the image to be processed by Tesseract
+
+* **lang** Language code
+
+* **config** Any additional configurations, ex: ```config="-psm 6"```
+
+* **nice** Modifies the processor priority for the Tesseract run. Not supported on Windows. Nice adjusts the niceness of unix-like processes.
 
 
 INSTALLATION

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Add the following config, if you have tessdata error like: "Error opening data f
 
 * **image_to_data** Returns string output containing box boundaries, confidences, and other information. Requires Tesseract 3.05+ (see <a href="https://github.com/tesseract-ocr/tesseract/wiki/Command-Line-Usage#tsv-output-currently-available-in-305-dev-in-master-branch-on-github">Tesseract TSV documentation</a> for more information
 
-### Parameters
+**Parameters**
 
 ``def image_to_data(image, lang=None, config='', nice=0, format='dict')``
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,6 @@
 try:
     from pytesseract import image_to_string
+    from pytesseract import image_to_data
+    from pytesseract import image_to_boxes
 except ImportError:
     from pytesseract.pytesseract import image_to_string

--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -64,7 +64,7 @@ def run_tesseract(input_filename,
                   output_filename_base,
                   extension,
                   lang,
-                  config=None,
+                  config='',
                   nice=0):
     command = []
 
@@ -76,12 +76,9 @@ def run_tesseract(input_filename,
     if lang is not None:
         command += ('-l', lang)
 
-    if config:
-        command += shlex.split(config)
+    command += shlex.split(config)
 
-    if extension == 'box':
-        command += ('batch.nochop', 'makebox')
-    else:
+    if extension != 'box':
         command.append(extension)
 
     proc = subprocess.Popen(command, stderr=subprocess.PIPE)
@@ -102,7 +99,7 @@ def prepare(image):
 
     raise TypeError('Unsupported image object')
 
-def run_and_get_output(image, extension, lang=None, config=None, nice=None):
+def run_and_get_output(image, extension, lang=None, config='', nice=None):
     temp_name = ''
     try:
         temp_name = save_image(image)
@@ -114,7 +111,7 @@ def run_and_get_output(image, extension, lang=None, config=None, nice=None):
     finally:
         cleanup(temp_name)
 
-def image_to_string(image, lang=None, config=None, nice=0):
+def image_to_string(image, lang=None, config='', nice=0, boxes=False):
     '''
     Runs tesseract on the specified image. First, the image is written to disk,
     and then the tesseract command is run on the image. Tesseract's OCR result is
@@ -124,9 +121,14 @@ def image_to_string(image, lang=None, config=None, nice=0):
     If nice is not set to 0, Tesseract process will run with changed priority.
     Not supported on Windows. Nice adjusts the niceness of unix-like processes.
     '''
+    if boxes:
+        # Added for backwards compatibility
+        print('\nWarning: Argument \'boxes\' is deprecated and will be removed'
+        ' in future versions. Use function image_to_boxes instead.\n')
+        return image_to_boxes(image, lang, config, nice)
     return run_and_get_output(image, 'txt', lang, config, nice)
 
-def image_to_boxes(image, lang=None, config=None, nice=0):
+def image_to_boxes(image, lang=None, config='', nice=0):
     '''
     Runs tesseract on the specified image. First, the image is written to disk,
     and then the tesseract command is run on the image. Tesseract's box file 
@@ -137,9 +139,10 @@ def image_to_boxes(image, lang=None, config=None, nice=0):
     If nice is not set to 0, Tesseract process will run with changed priority.
     Not supported on Windows. Nice adjusts the niceness of unix-like processes.
     '''
+    config += 'batch.nochop makebox'
     return run_and_get_output(image, 'box', lang, config, nice)
 
-def image_to_data(image, lang=None, config=None, nice=0):
+def image_to_data(image, lang=None, config='', nice=0):
     '''
     Runs tesseract on the specified image. First, the image is written to disk,
     and then the tesseract command is run on the image. Tesseract's tsv file results

--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -22,11 +22,10 @@ numpy_installed = True if find_loader('numpy') is not None else False
 if numpy_installed:
     from numpy import ndarray
 
-__all__ = ['image_to_string']
+__all__ = ['image_to_string', 'image_to_boxes', 'image_to_data']
 
 # CHANGE THIS IF TESSERACT IS NOT IN YOUR PATH, OR IS NAMED DIFFERENTLY
 tesseract_cmd = 'tesseract'
-
 
 class TesseractError(Exception):
     def __init__(self, status, message):
@@ -50,20 +49,23 @@ def cleanup(temp_name):
             pass
 
 
+def save_image(image, boxes=False):
+    image = prepare(image)
+    if len(image.getbands()) == 4:
+        # In case we have 4 channels, lets discard the Alpha.
+        image = image.convert('RGB')
+
+    temp_name = tempfile.mktemp(prefix='tess_')
+    input_file_name = temp_name + '.bmp'
+    image.save(input_file_name)
+    return temp_name
+
 def run_tesseract(input_filename,
                   output_filename_base,
-                  lang=None,
-                  boxes=False,
+                  extension,
+                  lang,
                   config=None,
-                  nice=0,
-                  verbose=0):
-    '''
-    runs the command:
-        `tesseract_cmd` `input_filename` `output_filename_base`
-
-    returns the exit status of tesseract, as well as tesseract's stderr output
-
-    '''
+                  nice=0):
     command = []
 
     if not sys.platform.startswith('win32') and nice != 0:
@@ -71,23 +73,25 @@ def run_tesseract(input_filename,
 
     command += (tesseract_cmd, input_filename, output_filename_base)
 
-    if verbose:
-        command.append('tsv')
-
     if lang is not None:
         command += ('-l', lang)
 
     if config:
         command += shlex.split(config)
 
-    if boxes:
+    if extension == 'box':
         command += ('batch.nochop', 'makebox')
+    else:
+        command.append(extension)
 
     proc = subprocess.Popen(command, stderr=subprocess.PIPE)
     status_code, error_string = proc.wait(), proc.stderr.read()
     proc.stderr.close()
-    return status_code, error_string
 
+    if status_code:
+        raise TesseractError(status, get_errors(error_string))
+
+    return True
 
 def prepare(image):
     if isinstance(image, Image.Image):
@@ -98,63 +102,54 @@ def prepare(image):
 
     raise TypeError('Unsupported image object')
 
-
-def image_to_string(image, lang=None, boxes=False, config=None, nice=0, verbose=0):
-    '''
-    Runs tesseract on the specified image. First, the image is written to disk,
-    and then the tesseract command is run on the image. Tesseract's result is
-    read, and the temporary files are erased.
-
-    Also supports boxes and config:
-
-    if boxes=True
-        "batch.nochop makebox" gets added to the tesseract call
-
-    if config is set, the config gets appended to the command.
-        ex: config="-psm 6"
-
-    If nice is not set to 0, Tesseract process will run with changed priority.
-    Not supported on Windows. Nice adjusts the niceness of unix-like processes.
-    '''
-
-    image = prepare(image)
-    if len(image.getbands()) == 4:
-        # In case we have 4 channels, lets discard the Alpha.
-        image = image.convert('RGB')
-
-    temp_name = tempfile.mktemp(prefix='tess_')
-    input_file_name = temp_name + '.bmp'
-    output_file_name_base = temp_name + '_out'
-    output_file_name = output_file_name_base + '.txt'
-
-    if boxes:
-        output_file_name = output_file_name_base + '.box'
-
+def run_and_get_output(image, extension, lang=None, config=None, nice=None):
+    temp_name = ''
     try:
-        image.save(input_file_name)
-        status, error_string = run_tesseract(input_file_name,
-                                             output_file_name_base,
-                                             lang=lang,
-                                             boxes=boxes,
-                                             config=config,
-                                             nice=nice,
-                                             verbose=verbose)
-
-        if status:
-            raise TesseractError(status, get_errors(error_string))
-
-        if verbose:
-            return read_tsv(output_file_name_base+'.tsv')
-
-        with open(output_file_name, 'rb') as output_file:
+        temp_name = save_image(image)
+        input_filename = temp_name+'.bmp'
+        output_filename_base = temp_name+'_out'
+        run_tesseract(input_filename, output_filename_base, extension, lang, config, nice)
+        with open(output_filename_base+'.'+extension, 'rb') as output_file:
             return output_file.read().decode('utf-8').strip()
     finally:
         cleanup(temp_name)
 
-def read_tsv(output_file_name):
-    with open(output_file_name, 'rb') as tsv_file:
-        rows = tsv_file.read().decode('utf-8').split('\n')
-        return {'header': rows.pop(0).split('\t'), 'data': [row.split('\t') for row in rows]}
+def image_to_string(image, lang=None, config=None, nice=0):
+    '''
+    Runs tesseract on the specified image. First, the image is written to disk,
+    and then the tesseract command is run on the image. Tesseract's OCR result is
+    read, and the temporary files are erased.
+    if config is set, the config gets appended to the command.
+        ex: config="-psm 6"
+    If nice is not set to 0, Tesseract process will run with changed priority.
+    Not supported on Windows. Nice adjusts the niceness of unix-like processes.
+    '''
+    return run_and_get_output(image, 'txt', lang, config, nice)
+
+def image_to_boxes(image, lang=None, config=None, nice=0):
+    '''
+    Runs tesseract on the specified image. First, the image is written to disk,
+    and then the tesseract command is run on the image. Tesseract's box file 
+    creation result is read, and the temporary files are erased.
+    "batch.nochop makebox" gets added to the tesseract call
+    if config is set, the config gets appended to the command.
+        ex: config="-psm 6"
+    If nice is not set to 0, Tesseract process will run with changed priority.
+    Not supported on Windows. Nice adjusts the niceness of unix-like processes.
+    '''
+    return run_and_get_output(image, 'box', lang, config, nice)
+
+def image_to_data(image, lang=None, config=None, nice=0):
+    '''
+    Runs tesseract on the specified image. First, the image is written to disk,
+    and then the tesseract command is run on the image. Tesseract's tsv file results
+    are read, and the temporary files are erased.
+    if config is set, the config gets appended to the command.
+        ex: config="-psm 6"
+    If nice is not set to 0, Tesseract process will run with changed priority.
+    Not supported on Windows. Nice adjusts the niceness of unix-like processes.
+    '''
+    return run_and_get_output(image, 'tsv', lang, config, nice)     
 
 def main():
     if len(sys.argv) == 2:


### PR DESCRIPTION
I had a project that required getting confidence values for the Tesseract run and saw that this library didn't support tsv files, so here's a proposal for a feature that I think will add a lot of value for users. The tsv file contains information about box positions/sizes, line and page numbers, and confidences, as well as providing the text. 

While this update to pytesseract is compatible with Python 2.4+ the tsv feature only exists in tesseract 3.05+

Current output:

```
level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	text
1	1	0	0	0	0	0	0	600	103	-1	
2	1	1	0	0	0	23	26	555	51	-1	
3	1	1	1	0	0	23	26	555	51	-1	
4	1	1	1	1	0	23	26	555	22	-1	
5	1	1	1	1	1	23	26	44	17	86	This
5	1	1	1	1	2	76	26	15	17	86	is
5	1	1	1	1	3	99	30	57	13	86	some
5	1	1	1	1	4	164	26	42	21	73	text,
5	1	1	1	1	5	215	26	70	17	82	written
5	1	1	1	1	6	295	26	15	17	95	in
5	1	1	1	1	7	317	26	52	21	73	Arial,
5	1	1	1	1	8	378	26	40	17	80	that
5	1	1	1	1	9	425	26	32	17	95	will
5	1	1	1	1	10	467	26	24	17	85	be
5	1	1	1	1	11	500	26	45	17	87	read
5	1	1	1	1	12	555	26	23	22	85	by
4	1	1	1	2	0	23	54	513	23	-1	
5	1	1	1	2	1	23	55	107	17	82	Tesseract.
5	1	1	1	2	2	140	55	49	17	91	Here
5	1	1	1	2	3	198	59	32	13	86	are
5	1	1	1	2	4	239	59	57	13	86	some
5	1	1	1	2	5	304	55	92	22	86	symbols:
5	1	1	1	2	6	407	54	129	23	65	!@#$%"&‘()
```