### PR TITLE
Output types

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,5 +2,9 @@ try:
     from pytesseract import image_to_string
     from pytesseract import image_to_data
     from pytesseract import image_to_boxes
+    from pytesseract import Output
 except ImportError:
     from pytesseract.pytesseract import image_to_string
+    from pytesseract.pytesseract import image_to_data
+    from pytesseract.pytesseract import image_to_boxes
+    from pytesseract.pytesseract import Output

--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -135,8 +135,7 @@ def run_and_get_output(image,
                 return output_file.read()
             return output_file.read().decode('utf-8').strip()
     finally:
-        print("not cleaning!")
-        # cleanup(temp_name)
+        cleanup(temp_name)
 
 
 def file_to_dict(tsv, cell_delimiter, str_col_idx):


### PR DESCRIPTION
Gives users the option between three return value types:
- String
- Dictionary
- Byte data (This could help with https://github.com/madmaze/pytesseract/issues/86) 

Default output type is Output.STRING

Usage:
```
>>> from PIL import Image
>>> import pytesseract
>>> from pytesseract import Output
>>> print(pytesseract.image_to_string(Image.open('test.png'), output_type=Output.BYTES))
b'This is some text, written in Arial, that will be read by\nTesseract. Here are some symbols: !@#$%"&\xe2\x80\x98()\n\n'
```