### PR TITLE
image_to_osd function

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,6 +2,7 @@ from .pytesseract import (
     image_to_string,
     image_to_data,
     image_to_boxes,
+    image_to_osd,
     TesseractError,
     Output
 )

--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -2,7 +2,6 @@
 
 '''
 Python-tesseract. For more information: https://github.com/madmaze/pytesseract
-
 '''
 
 try:
@@ -192,6 +191,20 @@ def file_to_dict(tsv, cell_delimiter, str_col_idx):
     return result
 
 
+def osd_to_dict(osd):
+    osd_keys = {
+        'Page number': ('page_num', int),
+        'Orientation in degrees': ('orientation', int),
+        'Rotate': ('rotate', int),
+        'Orientation confidence': ('orientation_conf', float),
+        'Script': ('script', str),
+        'Script confidence': ('script_conf', float)
+    }
+    lines = [line.split(': ') for line in osd.split('\n')]
+    return {osd_keys[k][0]: osd_keys[k][1](v) for k, v in lines}
+
+
+
 def image_to_string(image,
                     lang=None,
                     config='',
@@ -252,6 +265,25 @@ def image_to_data(image,
         return run_and_get_output(image, 'tsv', lang, config, nice, True)
 
     return run_and_get_output(image, 'tsv', lang, config, nice)
+
+
+def image_to_osd(image,
+                 lang=None,
+                 config='',
+                 nice=0,
+                 output_type=Output.STRING):
+    '''
+    Returns string containing the orientation and script detection (OSD)
+    '''
+    config += ' --psm 0'
+
+    if output_type == Output.DICT:
+        return osd_to_dict(
+            run_and_get_output(image, 'osd', lang, config, nice))
+    elif output_type == Output.BYTES:
+        return run_and_get_output(image, 'osd', lang, config, nice, True)
+
+    return run_and_get_output(image, 'osd', lang, config, nice)
 
 
 def main():

--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -24,6 +24,14 @@ if numpy_installed:
 # CHANGE THIS IF TESSERACT IS NOT IN YOUR PATH, OR IS NAMED DIFFERENTLY
 tesseract_cmd = 'tesseract'
 RGB_MODE = 'RGB'
+OSD_KEYS = {
+    'Page number': ('page_num', int),
+    'Orientation in degrees': ('orientation', int),
+    'Rotate': ('rotate', int),
+    'Orientation confidence': ('orientation_conf', float),
+    'Script': ('script', str),
+    'Script confidence': ('script_conf', float)
+}
 
 
 class Output:
@@ -192,17 +200,8 @@ def file_to_dict(tsv, cell_delimiter, str_col_idx):
 
 
 def osd_to_dict(osd):
-    osd_keys = {
-        'Page number': ('page_num', int),
-        'Orientation in degrees': ('orientation', int),
-        'Rotate': ('rotate', int),
-        'Orientation confidence': ('orientation_conf', float),
-        'Script': ('script', str),
-        'Script confidence': ('script_conf', float)
-    }
-    lines = [line.split(': ') for line in osd.split('\n')]
-    return {osd_keys[k][0]: osd_keys[k][1](v) for k, v in lines}
-
+    lines = (line.split(': ') for line in osd.split('\n'))
+    return {OSD_KEYS[k][0]: OSD_KEYS[k][1](v) for k, v in lines}
 
 
 def image_to_string(image,


### PR DESCRIPTION
I've implemented the `image_to_osd` function to get the output of a Tesseract execution with `--psm 0`, because I saw that it didn't worked with the other functions.

I've preferred to insert a new function instead of adding this functionality to `image_to_string` because the ouput is very different to a normal Tesseract execution, especially with a dictionary as output, where I thought it was better to create one with the OSD parameters, that's why I've created the `osd_to_dict` function.