### PR TITLE
Improved errors descript

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,19 +45,19 @@ USAGE
 
     # Simple image to string
     print(pytesseract.image_to_string(Image.open('test.png')))
-    
+
     # French text image to string
     print(pytesseract.image_to_string(Image.open('test-european.jpg'), lang='fra'))
-    
+
     # Get bounding box estimates
     print(pytesseract.image_to_boxes(Image.open('test.png')))
-    
+
     # Get verbose data including boxes, confidences, line and page numbers
     print(pytesseract.image_to_data(Image.open('test.png')))
-    
+
     # Get informations about orientation and script detection
     print(pytesseract.image_to_osd(Image.open('test.png'))
-    
+
 Support for OpenCV image/NumPy array objects
 
 .. code-block:: python
@@ -81,6 +81,8 @@ Add the following config, if you have tessdata error like: "Error opening data f
 
 
 **Functions**
+
+* **get_tesseract_version** Returns the Tesseract version installed in the system.
 
 * **image_to_string** Returns the result of a Tesseract OCR run on the image to string
 
@@ -113,12 +115,12 @@ Prerequisites:
 - Python-tesseract requires python 2.5+ or python 3.x
 - You will need the Python Imaging Library (PIL) (or the Pillow fork).
   Under Debian/Ubuntu, this is the package **python-imaging** or **python3-imaging**.
-- Install `Google Tesseract OCR <https://github.com/tesseract-ocr/tesseract>`_ 
+- Install `Google Tesseract OCR <https://github.com/tesseract-ocr/tesseract>`_
   (additional info how to install the engine on Linux, Mac OSX and Windows).
   You must be able to invoke the tesseract command as *tesseract*. If this
   isn't the case, for example because tesseract isn't in your PATH, you will
   have to change the "tesseract_cmd" variable ``pytesseract.pytesseract.tesseract_cmd``.
-  Under Debian/Ubuntu you can use the package **tesseract-ocr**. 
+  Under Debian/Ubuntu you can use the package **tesseract-ocr**.
   For Mac OS users. please install homebrew package **tesseract**.
 
 | Installing via pip:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,5 @@
 from .pytesseract import (
+    get_tesseract_version,
     image_to_string,
     image_to_data,
     image_to_boxes,

--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -244,7 +244,7 @@ def get_tesseract_version():
     '''
     try:
         return subprocess.check_output(
-            [tesseract_cmd, '--version']
+            [tesseract_cmd, '--version'], stderr=subprocess.STDOUT
         ).decode('utf-8').split()[1]
     except OSError:
         raise TesseractNotFoundError()

--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -17,7 +17,7 @@ import tempfile
 import shlex
 from glob import iglob
 
-numpy_installed = True if find_loader('numpy') is not None else False
+numpy_installed = find_loader('numpy') is not None
 if numpy_installed:
     from numpy import ndarray
 
@@ -183,7 +183,7 @@ def file_to_dict(tsv, cell_delimiter, str_col_idx):
         return result
 
     header = rows.pop(0)
-    if rows and len(rows[-1]) < len(header):
+    if len(rows[-1]) < len(header):
         # Fixes bug that occurs when last text string in TSV is null, and
         # last row is missing a final cell in TSV file
         rows[-1].append('')
@@ -219,6 +219,13 @@ def osd_to_dict(osd):
             line.split(': ') for line in osd.split('\n')
         ) if len(kv) == 2 and is_valid(kv[1], OSD_KEYS[kv[0]][1])
     }
+
+
+def get_tesseract_version():
+    '''
+    Returns a string containing the Tesseract version.
+    '''
+    return subprocess.check_output([tesseract_cmd, '--version']).split()[1]
 
 
 def image_to_string(image,


### PR DESCRIPTION
I think that the current errors messages are unclear about what went wrong. I have improved these messages when the tesseract command is not found and when the function `image_to_data` is used in the older Tesseract versions.  Now it launches two custom exceptions with a clearer message for each one: `TesseractNotFoundError` and `TSVNotSupported`. I have also implemented the function `get_tesseract_version()` which returns a string of the Tesseract version found in the system, I think that it could be useful.