### PR TITLE
Add pep8-naming plugin to pep8 tox env

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,2 @@
 flake8
+pep8-naming


### PR DESCRIPTION
See https://github.com/PyCQA/pep8-naming#plugin-for-flake8 to the list of additional checks this plugin adds to `flake8`.

The current code all complied, so no code changes were needed.