### PR TITLE
Close temp file descriptor

### DIFF
--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -162,7 +162,8 @@ def prepare(image):
 
 
 def save_image(image):
-    _, temp_name = tempfile.mkstemp(prefix='tess_')
+    fd, temp_name = tempfile.mkstemp(prefix='tess_')
+    os.close(fd)
     if isinstance(image, str):
         return temp_name, realpath(normpath(normcase(image)))
 


### PR DESCRIPTION
This pull request closes the open file descriptor returned by `tempfile.mkstemp`. Without this change, I believe pytesseract leaks open file descriptors every time it is called.

Quoting from the documentation:

> mkstemp() returns a tuple containing an OS-level handle to an open file (as would be returned by os.open()) and the absolute pathname of that file, in that order.

A script I ran to process frames of a long video eventually terminated due to `OSError: [Errno 24] Too many open files`, and `lsof` also showed the number of open files steadily increasing. After making this change, the problem has gone away, and `lsof` also indicates that we're no longer leaking file descriptors.