### PR TITLE
Proper handling of OSError exceptions

### DIFF
--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -137,7 +137,7 @@ def cleanup(temp_name):
         except OSError as e:
             if e.errno is not ENOENT:
                 raise e
-            
+
 
 def prepare(image):
     if numpy_installed and isinstance(image, ndarray):

--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -227,7 +227,7 @@ def run_tesseract(input_filename,
         if e.errno is not ENOENT:
             raise e
         raise TesseractNotFoundError()
-            
+
     with timeout_manager(proc, timeout) as error_string:
         if proc.returncode:
             raise TesseractError(proc.returncode, get_errors(error_string))

--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -10,6 +10,7 @@ import string
 import subprocess
 import sys
 import tempfile
+from errno import ENOENT
 from contextlib import contextmanager
 from csv import QUOTE_NONE
 from distutils.version import LooseVersion
@@ -133,9 +134,10 @@ def cleanup(temp_name):
     for filename in iglob(temp_name + '*' if temp_name else temp_name):
         try:
             os.remove(filename)
-        except OSError:
-            pass
-
+        except OSError as e:
+            if e.errno is not ENOENT:
+                raise e
+            
 
 def prepare(image):
     if numpy_installed and isinstance(image, ndarray):
@@ -221,9 +223,11 @@ def run_tesseract(input_filename,
 
     try:
         proc = subprocess.Popen(cmd_args, **subprocess_args())
-    except OSError:
+    except OSError as e:
+        if e.errno is not ENOENT:
+            raise e
         raise TesseractNotFoundError()
-
+            
     with timeout_manager(proc, timeout) as error_string:
         if proc.returncode:
             raise TesseractError(proc.returncode, get_errors(error_string))

--- a/tests/test_pytesseract.py
+++ b/tests/test_pytesseract.py
@@ -287,7 +287,7 @@ def test_wrong_tesseract_cmd(test_file, path):
         'invalid_path'
     ]
 )
-def test_proper_oserror_exception_handling(tesT_file, path):
+def test_proper_oserror_exception_handling(test_file, path):
     """"Test for bubbling up OSError exceptions."""
     import pytesseract
     pytesseract.pytesseract.tesseract_cmd = path

--- a/tests/test_pytesseract.py
+++ b/tests/test_pytesseract.py
@@ -261,7 +261,6 @@ def test_wrong_prepare_type(obj):
 @pytest.mark.parametrize(
     'path', [
         r'wrong_tesseract',
-        r'',
         getcwd() + path.sep + r'wrong_tesseract',
         ],
     ids=[
@@ -275,5 +274,24 @@ def test_wrong_tesseract_cmd(test_file, path):
     import pytesseract
     pytesseract.pytesseract.tesseract_cmd = path
     with pytest.raises(pytesseract.pytesseract.TesseractNotFoundError):
+        pytesseract.pytesseract.image_to_string(test_file)
+    pytesseract.pytesseract.tesseract_cmd = 'tesseract'  # restore the def value
+
+
+@pytest.mark.parametrize(
+    'path', [
+        path.sep + r'wrong_tesseract',
+        r''
+    ],
+    ids=[
+        'permission_error_path',
+        'invalid_path'
+    ]
+)
+def test_proper_oserror_exception_handling(tesT_file, path):
+    """"Test for bubbling up OSError exceptions."""
+    import pytesseract
+    pytesseract.pytesseract.tesseract_cmd = path
+    with pytest.raises(OSError):
         pytesseract.pytesseract.image_to_string(test_file)
     pytesseract.pytesseract.tesseract_cmd = 'tesseract'  # restore the def value

--- a/tests/test_pytesseract.py
+++ b/tests/test_pytesseract.py
@@ -262,10 +262,9 @@ def test_wrong_prepare_type(obj):
     'path', [
         r'wrong_tesseract',
         getcwd() + path.sep + r'wrong_tesseract',
-        ],
+    ],
     ids=[
         'executable_name',
-        'empty_name',
         'absolute_path',
     ]
 )

--- a/tests/test_pytesseract.py
+++ b/tests/test_pytesseract.py
@@ -8,6 +8,7 @@ import pytest
 from pytesseract import (
     Output,
     TSVNotSupported,
+    TesseractNotFoundError
     get_tesseract_version,
     image_to_boxes,
     image_to_data,
@@ -272,7 +273,7 @@ def test_wrong_tesseract_cmd(test_file, path):
     """Test wrong or missing tesseract command."""
     import pytesseract
     pytesseract.pytesseract.tesseract_cmd = path
-    with pytest.raises(pytesseract.pytesseract.TesseractNotFoundError):
+    with pytest.raises(TesseractNotFoundError):
         pytesseract.pytesseract.image_to_string(test_file)
     pytesseract.pytesseract.tesseract_cmd = 'tesseract'  # restore the def value
 
@@ -291,6 +292,6 @@ def test_proper_oserror_exception_handling(test_file, path):
     """"Test for bubbling up OSError exceptions."""
     import pytesseract
     pytesseract.pytesseract.tesseract_cmd = path
-    with pytest.raises(OSError):
+    with pytest.raises(TesseractNotFoundError if IS_PYTHON_2 else OSError):
         pytesseract.pytesseract.image_to_string(test_file)
     pytesseract.pytesseract.tesseract_cmd = 'tesseract'  # restore the def value

--- a/tests/test_pytesseract.py
+++ b/tests/test_pytesseract.py
@@ -8,7 +8,7 @@ import pytest
 from pytesseract import (
     Output,
     TSVNotSupported,
-    TesseractNotFoundError
+    TesseractNotFoundError,
     get_tesseract_version,
     image_to_boxes,
     image_to_data,
@@ -292,6 +292,8 @@ def test_proper_oserror_exception_handling(test_file, path):
     """"Test for bubbling up OSError exceptions."""
     import pytesseract
     pytesseract.pytesseract.tesseract_cmd = path
-    with pytest.raises(TesseractNotFoundError if IS_PYTHON_2 else OSError):
+    with pytest.raises(
+        TesseractNotFoundError if IS_PYTHON_2 and path else OSError
+    ):
         pytesseract.pytesseract.image_to_string(test_file)
     pytesseract.pytesseract.tesseract_cmd = 'tesseract'  # restore the def value

--- a/tests/test_pytesseract.py
+++ b/tests/test_pytesseract.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-import os.path
+from os import getcwd, path
 from multiprocessing import Pool
 from sys import platform, version_info
 
@@ -39,8 +39,8 @@ IS_PYTHON_3 = not IS_PYTHON_2
 
 TESSERACT_VERSION = tuple(get_tesseract_version().version)  # to skip tests
 
-DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
-TEST_JPEG = os.path.join(DATA_DIR, 'test.jpg')
+DATA_DIR = path.join(path.dirname(path.abspath(__file__)), 'data')
+TEST_JPEG = path.join(DATA_DIR, 'test.jpg')
 
 pytestmark = pytest.mark.pytesseract  # used marker for the module
 
@@ -52,7 +52,7 @@ def test_file():
 
 @pytest.fixture(scope='session')
 def test_file_european():
-    return os.path.join(DATA_DIR, 'test-european.jpg')
+    return path.join(DATA_DIR, 'test-european.jpg')
 
 
 @pytest.mark.parametrize(
@@ -82,7 +82,7 @@ def test_image_to_string_with_image_type(test_file):
     # that pytesseract command line program is called correctly.
     if test_file.endswith('gif') and TESSERACT_VERSION[0] < 4:
         pytest.skip('skip gif test')
-    test_file_path = os.path.join(DATA_DIR, test_file)
+    test_file_path = path.join(DATA_DIR, test_file)
     assert 'The quick brown dog' in image_to_string(test_file_path, 'eng')
 
 
@@ -118,14 +118,14 @@ def test_image_to_string_european(test_file_european):
     reason='used paths with `/` as separator'
 )
 def test_image_to_string_batch():
-    batch_file = os.path.join(DATA_DIR, 'images.txt')
+    batch_file = path.join(DATA_DIR, 'images.txt')
     assert 'The quick brown dog' in image_to_string(batch_file)
 
 
 def test_image_to_string_multiprocessing():
     """Test parallel system calls."""
     test_files = ['test.jpg', 'test.pgm', 'test.png', 'test.ppm', 'test.tiff']
-    test_files = [os.path.join(DATA_DIR, test_file) for test_file in test_files]
+    test_files = [path.join(DATA_DIR, test_file) for test_file in test_files]
     p = Pool(2)
     results = p.map(image_to_string, test_files)
     for result in results:
@@ -262,7 +262,7 @@ def test_wrong_prepare_type(obj):
     'path', [
         r'wrong_tesseract',
         r'',
-        os.path.sep + r'wrong_tesseract',
+        getcwd() + path.sep + r'wrong_tesseract',
         ],
     ids=[
         'executable_name',


### PR DESCRIPTION
Allow bubbling up all non-pytesseract related OSError exception.
Fixes #228 - check the issue for more details.