### PR TITLE
Fix the handling for the timeout feature

### DIFF
--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -104,7 +104,7 @@ def timeout_manager(proc, seconds=0):
             yield error_string
         finally:
             timer.cancel()
-            if proc.returncode is timeout_code:
+            if proc.returncode == timeout_code:
                 raise RuntimeError('Tesseract process timeout')
     finally:
         proc.stdin.close()
@@ -135,7 +135,7 @@ def cleanup(temp_name):
         try:
             os.remove(filename)
         except OSError:
-            if e.errno == ENOENT:
+            if e.errno != ENOENT:
                 raise e
 
 
@@ -224,7 +224,7 @@ def run_tesseract(input_filename,
     try:
         proc = subprocess.Popen(cmd_args, **subprocess_args())
     except OSError as e:
-        if e.errno == ENOENT:
+        if e.errno != ENOENT:
             raise e
         raise TesseractNotFoundError()
 

--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -104,7 +104,7 @@ def timeout_manager(proc, seconds=0):
             yield error_string
         finally:
             timer.cancel()
-            if proc.returncode is timeout_code and not error_string:
+            if proc.returncode is timeout_code:
                 raise RuntimeError('Tesseract process timeout')
     finally:
         proc.stdin.close()
@@ -134,8 +134,8 @@ def cleanup(temp_name):
     for filename in iglob(temp_name + '*' if temp_name else temp_name):
         try:
             os.remove(filename)
-        except OSError as e:
-            if e.errno is not ENOENT:
+        except OSError:
+            if e.errno == ENOENT:
                 raise e
 
 
@@ -224,7 +224,7 @@ def run_tesseract(input_filename,
     try:
         proc = subprocess.Popen(cmd_args, **subprocess_args())
     except OSError as e:
-        if e.errno is not ENOENT:
+        if e.errno == ENOENT:
             raise e
         raise TesseractNotFoundError()
 

--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -134,7 +134,7 @@ def cleanup(temp_name):
     for filename in iglob(temp_name + '*' if temp_name else temp_name):
         try:
             os.remove(filename)
-        except OSError:
+        except OSError as e:
             if e.errno != ENOENT:
                 raise e
 


### PR DESCRIPTION
Raising RuntimeError properly, instead of shadowing it in favor of TesseractError.
The problem was that even if we kill the tesseract process, it still sends some text to stderr.
I we made incorrect assumption, when developing the timeout feature - that the stderr will be empty, when we try to kill the process, while the OCR process is running.