### PR TITLE
delete format kwarg

### DIFF
--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -168,7 +168,7 @@ def save(image):
 
             image, extension = prepare(image)
             input_file_name = f.name + extsep + extension
-            image.save(input_file_name, format=extension, **image.info)
+            image.save(input_file_name, **image.info)
             yield f.name, input_file_name
     finally:
         cleanup(f.name)


### PR DESCRIPTION
In `save` func, `input_file_name` is parsed and used in `format` kwarg to save the image. Image.info already has `format`key

This causes  `multiple values for keyword argument 'format'` error

PIL==6.2.1
pytesseract==0.3.1