### PR TITLE
Update pytesseract.py

### DIFF
--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -272,7 +272,7 @@ def run_and_get_output(
         with open(filename, 'rb') as output_file:
             if return_bytes:
                 return output_file.read()
-            return output_file.read().decode('utf-8').strip()
+            return output_file.read().decode('utf-8')
 
 
 def file_to_dict(tsv, cell_delimiter, str_col_idx):


### PR DESCRIPTION
Found a bug that happens when you batch-process a number of pictures.
Tesseract writes recognized text to file using (here and after utf-8 decoded on read) "\n" and "\f" symbols, where first stands for "picture recognition result end" and second for "end-of-page in original source picture"(if it has multiple pages, or even one - still)

So normally for one-paged files you'll see an output like:
"text1\n\ftext2\n\ftext3\n\f" 
in tesseract output file, which currently will be then processed in pytesseract with .strip() and will lose the last "\n\f". Using .splitlines() it still could be split into three single strings without mistakes.

Bug happens when your first or last files in a batch sequence contain no text data(which is normal!) or fail to be recognized, therefore its result = '', an empty string. For this case, tesseract's output looks like:
"\n\ftext2\n\f\n\f" what could be .splitlines() processed to three strings, first and third are empty, second is "text2".
BUT being given to current pytesseract's .split(), it loses information about the first and last empty files, looking like just "text2", so .splitlines() returns you only one string, like you have given one file to process, and you won't be able to guess to which actual picture this single string belongs, and which have nothing in it.

So my proposal is to delete this .split(). I have tested such a fork and now it works perfectly predictable.

