### PR TITLE
Use the default Tesseract install dir on Windows

### DIFF
--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -22,8 +22,11 @@ try:
 except ImportError:
     import Image
 
-
-tesseract_cmd = 'tesseract'
+if sys.platform == 'win32':
+    # Assume default location installation of Tesseract
+    tesseract_cmd = "C:\\Program Files\\Tesseract-OCR\\Tesseract.exe"
+else:
+    tesseract_cmd = 'tesseract'
 
 numpy_installed = find_loader('numpy') is not None
 if numpy_installed:

--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -24,7 +24,7 @@ except ImportError:
 
 if sys.platform == 'win32':
     # Assume default location installation of Tesseract
-    tesseract_cmd = "C:\\Program Files\\Tesseract-OCR\\Tesseract.exe"
+    tesseract_cmd = 'C:\\Program Files\\Tesseract-OCR\\Tesseract.exe'
 else:
     tesseract_cmd = 'tesseract'
 


### PR DESCRIPTION
Rather than using the shell=True parameter on subprocess executions use the default installation directory to locate Teseract.

Addresses #272