### PR TITLE
Add support for outputting ALTO XML (>=4.1.0)

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,6 +8,7 @@ from .pytesseract import (  # noqa: F401
     image_to_data,
     image_to_osd,
     image_to_pdf_or_hocr,
+    image_to_alto_xml,
     image_to_string,
     run_and_get_output,
 )

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4,11 +4,11 @@ from .pytesseract import (  # noqa: F401
     TesseractNotFoundError,
     TSVNotSupported,
     get_tesseract_version,
+    image_to_alto_xml,
     image_to_boxes,
     image_to_data,
     image_to_osd,
     image_to_pdf_or_hocr,
-    image_to_alto_xml,
     image_to_string,
     run_and_get_output,
 )

--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -389,7 +389,9 @@ def image_to_alto_xml(
     if get_tesseract_version() < '4.1.0':
         raise ALTONotSupported()
 
-    config = '{} {}'.format('-c tessedit_create_alto=1', config.strip()).strip()
+    config = '{} {}'.format(
+        '-c tessedit_create_alto=1', config.strip(),
+    ).strip()
     args = [image, 'xml', lang, config, nice, timeout, True]
 
     return run_and_get_output(*args)

--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -382,6 +382,10 @@ def image_to_pdf_or_hocr(
 def image_to_alto_xml(
     image, lang=None, config='', nice=0, timeout=0,
 ):
+    """
+    Returns the result of a Tesseract OCR run on the provided image to ALTO XML
+    """
+
     if get_tesseract_version() < '4.1.0':
         raise ALTONotSupported()
     config = '{} {}'.format('-c tessedit_create_alto=1', config.strip()).strip()

--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -388,8 +388,10 @@ def image_to_alto_xml(
 
     if get_tesseract_version() < '4.1.0':
         raise ALTONotSupported()
+
     config = '{} {}'.format('-c tessedit_create_alto=1', config.strip()).strip()
     args = [image, 'xml', lang, config, nice, timeout, True]
+
     return run_and_get_output(*args)
 
 

--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -91,6 +91,13 @@ class TSVNotSupported(EnvironmentError):
         )
 
 
+class ALTONotSupported(EnvironmentError):
+    def __init__(self):
+        super(ALTONotSupported, self).__init__(
+            'ALTO output not supported. Tesseract >= 4.10 required',
+        )
+
+
 def kill(process, code):
     process.kill()
     process.returncode = code

--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -382,7 +382,7 @@ def image_to_pdf_or_hocr(
 def image_to_alto_xml(
     image, lang=None, config='', nice=0, timeout=0,
 ):
-    if get_tesseract_version() < '4.10':
+    if get_tesseract_version() < '4.1.0':
         raise ALTONotSupported()
     config = '{} {}'.format('-c tessedit_create_alto=1', config.strip()).strip()
     args = [image, 'xml', lang, config, nice, timeout, True]

--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -94,7 +94,7 @@ class TSVNotSupported(EnvironmentError):
 class ALTONotSupported(EnvironmentError):
     def __init__(self):
         super(ALTONotSupported, self).__init__(
-            'ALTO output not supported. Tesseract >= 4.10 required',
+            'ALTO output not supported. Tesseract >= 4.1.0 required',
         )
 
 

--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -234,7 +234,7 @@ def run_tesseract(
     if config:
         cmd_args += shlex.split(config)
 
-    if extension and extension not in {'box', 'osd', 'tsv'}:
+    if extension and extension not in {'box', 'osd', 'tsv', 'xml'}:
         cmd_args.append(extension)
 
     try:
@@ -376,6 +376,16 @@ def image_to_pdf_or_hocr(
         raise ValueError('Unsupported extension: {}'.format(extension))
     args = [image, extension, lang, config, nice, timeout, True]
 
+    return run_and_get_output(*args)
+
+
+def image_to_alto_xml(
+    image, lang=None, config='', nice=0, timeout=0,
+):
+    if get_tesseract_version() < '4.10':
+        raise ALTONotSupported()
+    config = '{} {}'.format('-c tessedit_create_alto=1', config.strip()).strip()
+    args = [image, 'xml', lang, config, nice, timeout, True]
     return run_and_get_output(*args)
 
 

--- a/tests/pytesseract_test.py
+++ b/tests/pytesseract_test.py
@@ -203,6 +203,9 @@ def test_image_to_pdf_or_hocr(test_file, extension):
         assert result.endswith('</html>')
 
 
+@pytest.mark.skipif(
+    TESSERACT_VERSION[:2] < (4, 1), reason='requires tesseract < 3.05',
+)
 def test_image_to_alto_xml(test_file):
     result = image_to_alto_xml(test_file)
     assert isinstance(result, bytes)

--- a/tests/pytesseract_test.py
+++ b/tests/pytesseract_test.py
@@ -11,6 +11,7 @@ from pytesseract import (
     TesseractNotFoundError,
     TSVNotSupported,
     get_tesseract_version,
+    image_to_alto_xml,
     image_to_boxes,
     image_to_data,
     image_to_osd,
@@ -200,6 +201,15 @@ def test_image_to_pdf_or_hocr(test_file, extension):
         result = str(result).strip()
         assert result.startswith('<?xml')
         assert result.endswith('</html>')
+
+
+def test_image_to_alto_xml(test_file):
+    result = image_to_alto_xml(test_file)
+    assert isinstance(result, bytes)
+    result = result.decode('utf-8') if IS_PYTHON_2 else str(result, 'utf-8')
+    result = str(result).strip()
+    assert result.startswith('<?xml')
+    assert result.endswith('</alto>')
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Mentioned in #234 

Tesseract has supported ALTO XML for over a year now, since 4.1.0. This pull request implements the function `image_to_alto_xml`, which returns ALTO XML as bytes. An exception is thrown if the Tesseract version is too old.

Tested with Tesseract versions:
4.0.0-beta.1 (Ubuntu 18.04): throws exception as excepted
4.1.1 (Ubuntu 20.04): works as expected
5.0.0-alpha-771-g7498 (recent development version built from source): works as expected

