### PR TITLE
fixing bug on method 'file_to_dict'

### DIFF
--- a/pytesseract/pytesseract.py
+++ b/pytesseract/pytesseract.py
@@ -299,6 +299,9 @@ def file_to_dict(tsv, cell_delimiter, str_col_idx):
         return result
 
     header = rows.pop(0)
+    if not rows:
+        return result
+    
     length = len(header)
     if len(rows[-1]) < length:
         # Fixes bug that occurs when last text string in TSV is null, and

--- a/pytesseract/pytesseract.py
+++ b/pytesseract/pytesseract.py
@@ -301,7 +301,7 @@ def file_to_dict(tsv, cell_delimiter, str_col_idx):
     header = rows.pop(0)
     if not rows:
         return result
-    
+
     length = len(header)
     if len(rows[-1]) < length:
         # Fixes bug that occurs when last text string in TSV is null, and

--- a/pytesseract/pytesseract.py
+++ b/pytesseract/pytesseract.py
@@ -295,13 +295,10 @@ def run_and_get_output(
 def file_to_dict(tsv, cell_delimiter, str_col_idx):
     result = {}
     rows = [row.split(cell_delimiter) for row in tsv.strip().split('\n')]
-    if not rows:
+    if len(rows) < 2:
         return result
 
     header = rows.pop(0)
-    if not rows:
-        return result
-
     length = len(header)
     if len(rows[-1]) < length:
         # Fixes bug that occurs when last text string in TSV is null, and


### PR DESCRIPTION
This is a possible solution for a bug on method 'file_to_dict' on pytesseract.py (line 303). An error comes up when ```rows``` has length 1. After ```rows.pop(0)```, ```rows``` become an empty list and the code crashes on the following lines.