### PR TITLE
Pyinstaller non-console problem is solved.

### DIFF
--- a/pytesseract/pytesseract.py
+++ b/pytesseract/pytesseract.py
@@ -222,6 +222,8 @@ def subprocess_args(include_stdout=True):
 
     if include_stdout:
         kwargs['stdout'] = subprocess.PIPE
+    else:
+        kwargs['stdout'] = subprocess.DEVNULL
 
     return kwargs
 
@@ -384,6 +386,7 @@ def get_tesseract_version():
                 [tesseract_cmd, '--version'],
                 stderr=subprocess.STDOUT,
                 env=environ,
+                stdin=subprocess.DEVNULL,
             )
             .decode(DEFAULT_ENCODING)
             .split()[1]


### PR DESCRIPTION
When I converted my ML solution to one file executable without console mode via pyinstaller pytesseract was not working. There was a subprocess problem. Problem was solved in this [issue](pyinstaller/pyinstaller#5601). I have updated the code for preventing future problems.