### PR TITLE
Remove Python 2-specific universal wheel specification

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,3 @@ console_scripts =
 exclude =
     tests*
     testing*
-
-[bdist_wheel]
-universal = True


### PR DESCRIPTION
Universal wheels are used to target both Python 2 and Python 3. Since this package targets Python 3.7+, this is no longer appropriate.