### PR TITLE
Fix the correct imaging package in Debian/Ubuntu

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -184,7 +184,7 @@ Prerequisites:
 
 - Python-tesseract requires Python 3.6+
 - You will need the Python Imaging Library (PIL) (or the `Pillow <https://pypi.org/project/Pillow/>`_ fork).
-  Under Debian/Ubuntu, this is the package **python-imaging** or **python3-imaging**.
+  Please check the `Pillow documentation <https://pillow.readthedocs.io/en/stable/installation.html#basic-installation>`_ to know the basic Pillow installation.
 - Install `Google Tesseract OCR <https://github.com/tesseract-ocr/tesseract>`_
   (additional info how to install the engine on Linux, Mac OSX and Windows).
   You must be able to invoke the tesseract command as *tesseract*. If this


### PR DESCRIPTION
# Changed log

- After checking the `python-imaging` and `python3-imaging` packages in Debian/Ubuntu, it seems that the package names are changed.
- When running the `` command, some related log outputs are as follows:

```
Reading package lists... Done
Building dependency tree
Reading state information... Done
Package python3-imaging is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  python3-pil:i386 python3-pil

E: Package 'python3-imaging' has no installation candidate
......
Reading package lists... Done
Building dependency tree
Reading state information... Done
Package python-imaging is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  python-pil:i386 python-pil

E: Package 'python-imaging' has no installation candidate
```

After running the `sudo apt-get install python-pil` and `sudo apt-get install python3-pil` commands, some log outputs are as follows:

```Bash
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  dh-python file libexpat1 libfreetype6 libjbig0 libjpeg-turbo8 libjpeg8
  liblcms2-2 libmagic1 libmpdec2 libpng12-0 libpython3-stdlib
  libpython3.5-minimal libpython3.5-stdlib libsqlite3-0 libssl1.0.0 libtiff5
  libwebp5 libwebpmux1 mime-support python3 python3-minimal python3.5
  python3.5-minimal
Suggested packages:
  libdpkg-perl liblcms2-utils python3-doc python3-tk python3-venv
  python-pil-doc python3-pil-dbg python3.5-venv python3.5-doc binutils
  binfmt-support
The following NEW packages will be installed:
  dh-python file libexpat1 libfreetype6 libjbig0 libjpeg-turbo8 libjpeg8
  liblcms2-2 libmagic1 libmpdec2 libpng12-0 libpython3-stdlib
  libpython3.5-minimal libpython3.5-stdlib libsqlite3-0 libssl1.0.0 libtiff5
  libwebp5 libwebpmux1 mime-support python3 python3-minimal python3-pil
  python3.5 python3.5-minimal
0 upgraded, 25 newly installed, 0 to remove and 0 not upgraded.
Need to get 7788 kB of archives.
After this operation, 37.7 MB of additional disk space will be used.
Do you want to continue? [Y/n]
.......
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following additional packages will be installed:
  python-olefile
Suggested packages:
  python-pil-doc python-pil-dbg
The following NEW packages will be installed:
  python-olefile python-pil
0 upgraded, 2 newly installed, 0 to remove and 0 not upgraded.
Need to get 336 kB of archives.
After this operation, 1,667 kB of additional disk space will be used.
Do you want to continue? [Y/n]
```