### PR TITLE
Add debug logging for CLI arguments

### DIFF
--- a/pytesseract/pytesseract.py
+++ b/pytesseract/pytesseract.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import logging
 import re
 import shlex
 import string
@@ -36,6 +37,8 @@ if numpy_installed:
 pandas_installed = find_loader('pandas') is not None
 if pandas_installed:
     import pandas as pd
+
+LOGGER = logging.getLogger('pytesseract')
 
 DEFAULT_ENCODING = 'utf-8'
 LANG_PATTERN = re.compile('^[a-z_]+$')
@@ -250,6 +253,7 @@ def run_tesseract(
 
     if extension and extension not in {'box', 'osd', 'tsv', 'xml'}:
         cmd_args.append(extension)
+    LOGGER.debug('%r', cmd_args)
 
     try:
         proc = subprocess.Popen(cmd_args, **subprocess_args())


### PR DESCRIPTION
This change adds debug logging to see which CLI arguments *pytesseract* passes to Tesseract itself. The goal is to simplify debugging reported issues, especially as most of them turn out to be related to plain Tesseract anyway, fixing the first part of #456.

### Example usage

```python3
import pytesseract
import logging

logging.basicConfig(level=logging.WARNING)
logging.getLogger('pytesseract').setLevel(logging.DEBUG)

image = '/home/stefan/Desktop/file.png'
print(pytesseract.image_to_string(image))
```

### Example output

```bash
DEBUG:pytesseract:['tesseract', '/home/stefan/Desktop/file.png', '/tmp/tess_0kncj5u3', 'txt']

This is my text.
```