### PR TITLE
allow multiple output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,10 @@ Library usage:
     # Get ALTO XML output
     xml = pytesseract.image_to_alto_xml('test.png')
 
+    # getting multiple types of output with one call to save compute time
+    # currently supports mix and match of the following: txt, pdf, hocr, box, tsv
+    text, boxes = pytesseract.run_and_get_multiple_output('test.png', extensions=['txt', 'box'])
+
 Support for OpenCV image/NumPy array objects
 
 .. code-block:: python

--- a/README.rst
+++ b/README.rst
@@ -157,6 +157,8 @@ Add the following config, if you have tessdata error like: "Error opening data f
 
 * **run_and_get_output** Returns the raw output from Tesseract OCR. Gives a bit more control over the parameters that are sent to tesseract.
 
+* **run_and_get_multiple_output** Returns like `run_and_get_output` but can handle multiple extensions. This function replaces the `extension: str` kwarg with `extension: List[str]` kwarg where a list of extensions can be specified and the corresponding data is returned after only one `tesseract` call. This function reduces the number of calls to `tesseract` when multiple output formats, like both text and bounding boxes,  are needed.
+
 **Parameters**
 
 ``image_to_data(image, lang=None, config='', nice=0, output_type=Output.STRING, timeout=0, pandas_config=None)``

--- a/pytesseract/__init__.py
+++ b/pytesseract/__init__.py
@@ -9,6 +9,7 @@ from .pytesseract import image_to_osd
 from .pytesseract import image_to_pdf_or_hocr
 from .pytesseract import image_to_string
 from .pytesseract import Output
+from .pytesseract import run_and_get_multiple_output
 from .pytesseract import run_and_get_output
 from .pytesseract import TesseractError
 from .pytesseract import TesseractNotFoundError

--- a/pytesseract/pytesseract.py
+++ b/pytesseract/pytesseract.py
@@ -21,6 +21,7 @@ from os.path import realpath
 from pkgutil import find_loader
 from tempfile import NamedTemporaryFile
 from time import sleep
+from typing import List, Optional
 
 from packaging.version import InvalidVersion
 from packaging.version import parse
@@ -63,6 +64,13 @@ OSD_KEYS = {
     'Orientation confidence': ('orientation_conf', float),
     'Script': ('script', str),
     'Script confidence': ('script_conf', float),
+}
+
+EXTENTION_TO_CONFIG = {
+    'box': 'tessedit_create_boxfile=1 batch.nochop makebox',
+    'xml': 'tessedit_create_alto=1',
+    'hocr': 'tessedit_create_hocr=1',
+    'tsv': 'tessedit_create_tsv=1',
 }
 
 TESSERACT_MIN_VERSION = Version('3.05')
@@ -252,8 +260,9 @@ def run_tesseract(
     if config:
         cmd_args += shlex.split(config, posix=not_windows)
 
-    if extension and extension not in {'box', 'osd', 'tsv', 'xml'}:
-        cmd_args.append(extension)
+    for _extension in extension.split():
+        if _extension not in {'box', 'osd', 'tsv', 'xml'}:
+            cmd_args.append(_extension)
     LOGGER.debug('%r', cmd_args)
 
     try:
@@ -267,6 +276,49 @@ def run_tesseract(
     with timeout_manager(proc, timeout) as error_string:
         if proc.returncode:
             raise TesseractError(proc.returncode, get_errors(error_string))
+
+
+def _read_output(filename: str, return_bytes: bool=False):
+    with open(filename, 'rb') as output_file:
+        if return_bytes:
+            return output_file.read()
+        return output_file.read().decode(DEFAULT_ENCODING)
+
+
+def run_and_get_multiple_output(
+    image,
+    extensions: List[str],
+    lang: Optional[str]=None,
+    nice: int=0,
+    timeout: int=0,
+    return_bytes: bool=False,
+):
+    config = ' '.join(EXTENTION_TO_CONFIG.get(extension, '') for extension in extensions).strip()
+    if config:
+        config = f"-c {config}"
+    else:
+        config = ''
+    
+    with save(image) as (temp_name, input_filename):
+        kwargs = {
+            'input_filename': input_filename,
+            'output_filename_base': temp_name,
+            'extension': " ".join(extensions),
+            'lang': lang,
+            'config': config,
+            'nice': nice,
+            'timeout': timeout,
+        }
+
+        run_tesseract(**kwargs)
+
+        return [
+            _read_output(
+                f"{kwargs['output_filename_base']}{extsep}{extension}",
+                True if extension in {'pdf', 'hocr'} else return_bytes
+            )
+            for extension in extensions
+        ]
 
 
 def run_and_get_output(
@@ -290,11 +342,7 @@ def run_and_get_output(
         }
 
         run_tesseract(**kwargs)
-        filename = f"{kwargs['output_filename_base']}{extsep}{extension}"
-        with open(filename, 'rb') as output_file:
-            if return_bytes:
-                return output_file.read()
-            return output_file.read().decode(DEFAULT_ENCODING)
+        return _read_output(f"{kwargs['output_filename_base']}{extsep}{extension}", return_bytes)
 
 
 def file_to_dict(tsv, cell_delimiter, str_col_idx):

--- a/pytesseract/pytesseract.py
+++ b/pytesseract/pytesseract.py
@@ -21,7 +21,8 @@ from os.path import realpath
 from pkgutil import find_loader
 from tempfile import NamedTemporaryFile
 from time import sleep
-from typing import List, Optional
+from typing import List
+from typing import Optional
 
 from packaging.version import InvalidVersion
 from packaging.version import parse
@@ -278,7 +279,7 @@ def run_tesseract(
             raise TesseractError(proc.returncode, get_errors(error_string))
 
 
-def _read_output(filename: str, return_bytes: bool=False):
+def _read_output(filename: str, return_bytes: bool = False):
     with open(filename, 'rb') as output_file:
         if return_bytes:
             return output_file.read()
@@ -288,22 +289,24 @@ def _read_output(filename: str, return_bytes: bool=False):
 def run_and_get_multiple_output(
     image,
     extensions: List[str],
-    lang: Optional[str]=None,
-    nice: int=0,
-    timeout: int=0,
-    return_bytes: bool=False,
+    lang: Optional[str] = None,
+    nice: int = 0,
+    timeout: int = 0,
+    return_bytes: bool = False,
 ):
-    config = ' '.join(EXTENTION_TO_CONFIG.get(extension, '') for extension in extensions).strip()
+    config = ' '.join(
+        EXTENTION_TO_CONFIG.get(extension, '') for extension in extensions
+    ).strip()
     if config:
-        config = f"-c {config}"
+        config = f'-c {config}'
     else:
         config = ''
-    
+
     with save(image) as (temp_name, input_filename):
         kwargs = {
             'input_filename': input_filename,
             'output_filename_base': temp_name,
-            'extension': " ".join(extensions),
+            'extension': ' '.join(extensions),
             'lang': lang,
             'config': config,
             'nice': nice,
@@ -315,7 +318,7 @@ def run_and_get_multiple_output(
         return [
             _read_output(
                 f"{kwargs['output_filename_base']}{extsep}{extension}",
-                True if extension in {'pdf', 'hocr'} else return_bytes
+                True if extension in {'pdf', 'hocr'} else return_bytes,
             )
             for extension in extensions
         ]
@@ -342,7 +345,10 @@ def run_and_get_output(
         }
 
         run_tesseract(**kwargs)
-        return _read_output(f"{kwargs['output_filename_base']}{extsep}{extension}", return_bytes)
+        return _read_output(
+            f"{kwargs['output_filename_base']}{extsep}{extension}",
+            return_bytes,
+        )
 
 
 def file_to_dict(tsv, cell_delimiter, str_col_idx):

--- a/tests/pytesseract_test.py
+++ b/tests/pytesseract_test.py
@@ -254,7 +254,7 @@ def test_run_and_get_pdf_and_txt(test_file, function_mapping):
     # This tests a case where the extensions do not add any config params
     # Here this test is not merged with the test above because we might get
     # into a racing condition where test results from different parameter
-    # are mixtued in test below
+    # are mixed in the test below
     extensions = ['pdf', 'txt']
     compound_results = run_and_get_multiple_output(
         test_file,


### PR DESCRIPTION
## summary

This PR resolves #304 by adding a new function `run_and_get_multiple_output` that can take multiple extensions (output formats) and return them after one invocation of `tesseract`. This saves compute time when the user tries to get multiple outputs from one input, e.g., 

```python
text, pdf = run_and_get_multiple_output(image, extensions=['txt', 'pdf'])
```

## walkthrough

The main addition in this PR is the function `run_and_get_multiple_output`. It accepts a list of extensions like `['pdf', 'txt']`. Internally this function:

1. assembles the command line config arguments needed by mapping each extension to its required config arguments (stored as a constant in `EXTENTION_TO_CONFIG`).
2. invokes `tesseract` just once to generate all the files needed
3. for each extension load its result and return in the same order as in the input `extensions`

Note that this PR only allows a subset of all supported extensions. This is to limit the config to those that are compatible to assemble. E.g., the extension `osd` requires a different command line param `--psm` instead of `-c` therefore is not supported yet by this new function.

This PR refactors the function `run_tesseract` so it can handle multiple extensions: the key change is to filter out extensions that do not need to be appended to the command line arguments.

This PR also refactors the code that reads the output into a helper `_read_output` so it can be reused by both the new `run_and_get_multiple_output` and existing `run_and_get_output`.

## test

This PR adds a unit test to test a few combinations of different extension lists. I'd encourage the reviewer to run the function locally with a simple example of 

```python
text, boxes = run_and_get_multiple_output(image, extensions=['txt', 'box'])
```

and compare its runtime to 

```python
text = image_to_string(image)
boxes = image_to_box(image)
```

The above example can a common usage pattern for followup analysis on the OCR results.
