### PR TITLE
Added support for image URLs

### DIFF
--- a/pytesseract/pytesseract.py
+++ b/pytesseract/pytesseract.py
@@ -209,7 +209,10 @@ def save(image):
     try:
         with NamedTemporaryFile(prefix='tess_', delete=False) as f:
             if isinstance(image, str):
-                yield f.name, realpath(normpath(normcase(image)))
+                if image.startswith('http:') or image.startswith('https:'):
+                    yield f.name, image
+                else:
+                    yield f.name, realpath(normpath(normcase(image)))
                 return
             image, extension = prepare(image)
             input_file_name = f'{f.name}_input{extsep}{extension}'

--- a/tests/pytesseract_test.py
+++ b/tests/pytesseract_test.py
@@ -50,6 +50,7 @@ TESTS_DIR = path.dirname(path.abspath(__file__))
 DATA_DIR = path.join(TESTS_DIR, 'data')
 TESSDATA_DIR = path.join(TESTS_DIR, 'tessdata')
 TEST_JPEG = path.join(DATA_DIR, 'test.jpg')
+TEST_JPEG_URL = 'https://i.imgur.com/hWO45US.jpg'
 
 pytestmark = pytest.mark.pytesseract  # used marker for the module
 string_type = unicode if IS_PYTHON_2 else str  # noqa: 821
@@ -120,6 +121,18 @@ def test_image_to_string_with_image_type(test_file):
     test_file_path = path.join(DATA_DIR, test_file)
     assert 'The quick brown dog' in image_to_string(test_file_path, 'eng')
 
+
+@pytest.mark.parametrize(
+    'test_file',
+    [TEST_JPEG_URL],
+    ids=['jpeg_url'],
+)
+def test_image_to_string_with_url(test_file):
+    # Tesseract-ocr supports image URLs from version 4.1.1
+    if TESSERACT_VERSION[0] < 4:
+        pytest.skip('skip url test')
+    assert 'The quick brown dog' in image_to_string(test_file)
+ 
 
 @pytest.mark.parametrize(
     'test_file',


### PR DESCRIPTION
Fixes #415
In the spirit of the repo being a wrapper, I left URL validation to the tesseract-ocr process. If you think it is something that should be handled here, let me know.