### PR TITLE
Allow multiple outputs with additional config options

### DIFF
--- a/pytesseract/pytesseract.py
+++ b/pytesseract/pytesseract.py
@@ -323,7 +323,7 @@ def run_and_get_multiple_output(
         return [
             _read_output(
                 f"{kwargs['output_filename_base']}{extsep}{extension}",
-                True if extension in {'pdf', 'hocr'} else return_bytes,
+                True if extension in {'pdf', 'hocr', 'xml'} else return_bytes,
             )
             for extension in extensions
         ]

--- a/pytesseract/pytesseract.py
+++ b/pytesseract/pytesseract.py
@@ -73,10 +73,10 @@ OSD_KEYS = {
 }
 
 EXTENTION_TO_CONFIG = {
-    'box': 'tessedit_create_boxfile=1 batch.nochop makebox',
-    'xml': 'tessedit_create_alto=1',
-    'hocr': 'tessedit_create_hocr=1',
-    'tsv': 'tessedit_create_tsv=1',
+    'box': '-c tessedit_create_boxfile=1 batch.nochop makebox',
+    'xml': '-c tessedit_create_alto=1',
+    'hocr': '-c tessedit_create_hocr=1',
+    'tsv': '-c tessedit_create_tsv=1',
 }
 
 TESSERACT_MIN_VERSION = Version('3.05')
@@ -295,17 +295,16 @@ def run_and_get_multiple_output(
     image,
     extensions: list[str],
     lang: str | None = None,
+    config: str = '',
     nice: int = 0,
     timeout: int = 0,
     return_bytes: bool = False,
 ):
-    config = ' '.join(
+    ext_config = ' '.join(
         EXTENTION_TO_CONFIG.get(extension, '') for extension in extensions
     ).strip()
-    if config:
-        config = f'-c {config}'
-    else:
-        config = ''
+    if ext_config:
+        config = f'{config.strip()} {ext_config}'
 
     with save(image) as (temp_name, input_filename):
         kwargs = {

--- a/tests/pytesseract_test.py
+++ b/tests/pytesseract_test.py
@@ -248,6 +248,10 @@ def test_image_to_pdf_or_hocr(test_file, extension):
     'extensions',
     [
         ['xml', 'tsv', 'pdf', 'txt', 'box', 'hocr'],
+        # This tests a case in which listing 'box' before 'tsv' or 'xml' adds
+        # configfiles to the config string, which prevents tsv and xml from being
+        # generated if their parameters are not preceded by "-c"
+        ['box', 'tsv', 'xml'],
         # This tests a case where the extensions do not add any config params
         # Here this test is not merged with the test above because we might get
         # into a racing condition where test results from different parameter
@@ -269,6 +273,33 @@ def test_run_and_get_multiple_output(test_file, function_mapping, extensions):
             )
         else:
             assert result == function_mapping[extension](test_file)
+
+
+@pytest.mark.parametrize(
+    'extensions,config',
+    [
+        (['tsv', 'pdf', 'txt', 'box', 'hocr'], '--dpi 300 --oem 3 --psm 6'),
+        (['box', 'hocr', 'tsv', 'txt'], '--dpi 300 --oem 3 --psm 6'),
+        # This tests a case where the extensions do not add any config params, as in
+        # the test for the same function without passing 'config'
+        (['pdf', 'txt'], '--dpi 300 --oem 3 --psm 6'),
+    ],
+)
+def test_run_and_get_multiple_output_with_config(test_file, function_mapping, extensions, config):
+    compound_results = run_and_get_multiple_output(
+        test_file,
+        extensions=extensions,
+        config=config
+    )
+    for result, extension in zip(compound_results, extensions):
+        if extension == 'pdf':
+            # pdf creation time could be different between the two so do not
+            # check the whole string
+            assert (
+                    result[:1000] == function_mapping[extension](test_file, config=config)[:1000]
+            )
+        else:
+            assert result == function_mapping[extension](test_file, config=config)
 
 
 @pytest.mark.skipif(

--- a/tests/pytesseract_test.py
+++ b/tests/pytesseract_test.py
@@ -249,8 +249,8 @@ def test_image_to_pdf_or_hocr(test_file, extension):
     [
         ['xml', 'tsv', 'pdf', 'txt', 'box', 'hocr'],
         # This tests a case in which listing 'box' before 'tsv' or 'xml' adds
-        # configfiles to the config string, which prevents tsv and xml from being
-        # generated if their parameters are not preceded by "-c"
+        # configfiles to the config string, which prevents tsv and xml from
+        # being generated if their parameters are not preceded by "-c"
         ['box', 'tsv', 'xml'],
         # This tests a case where the extensions do not add any config params
         # Here this test is not merged with the test above because we might get
@@ -280,8 +280,8 @@ def test_run_and_get_multiple_output(test_file, function_mapping, extensions):
     [
         (['tsv', 'pdf', 'txt', 'box', 'hocr'], '--dpi 300 --oem 3 --psm 6'),
         (['box', 'hocr', 'tsv', 'txt'], '--dpi 300 --oem 3 --psm 6'),
-        # This tests a case where the extensions do not add any config params, as in
-        # the test for the same function without passing 'config'
+        # This tests a case where the extensions do not add any config params,
+        # like in the test for the same function without passing 'config'
         (['pdf', 'txt'], '--dpi 300 --oem 3 --psm 6'),
     ],
 )

--- a/tests/pytesseract_test.py
+++ b/tests/pytesseract_test.py
@@ -86,6 +86,7 @@ def function_mapping():
         'box': image_to_boxes,
         'hocr': partial(image_to_pdf_or_hocr, extension='hocr'),
         'tsv': image_to_data,
+        'xml': image_to_alto_xml,
     }
 
 
@@ -246,7 +247,7 @@ def test_image_to_pdf_or_hocr(test_file, extension):
 @pytest.mark.parametrize(
     'extensions',
     [
-        ['tsv', 'pdf', 'txt', 'box', 'hocr'],
+        ['xml', 'tsv', 'pdf', 'txt', 'box', 'hocr'],
         # This tests a case where the extensions do not add any config params
         # Here this test is not merged with the test above because we might get
         # into a racing condition where test results from different parameter

--- a/tests/pytesseract_test.py
+++ b/tests/pytesseract_test.py
@@ -286,10 +286,15 @@ def test_run_and_get_multiple_output(test_file, function_mapping, extensions):
     ],
 )
 def test_run_and_get_multiple_output_with_config(
-    test_file, function_mapping, extensions, config,
+    test_file,
+    function_mapping,
+    extensions,
+    config,
 ):
     compound_results = run_and_get_multiple_output(
-        test_file, extensions=extensions, config=config,
+        test_file,
+        extensions=extensions,
+        config=config,
     )
     for result, extension in zip(compound_results, extensions):
         if extension == 'pdf':
@@ -301,7 +306,8 @@ def test_run_and_get_multiple_output_with_config(
             )
         else:
             assert result == function_mapping[extension](
-                test_file, config=config,
+                test_file,
+                config=config,
             )
 
 

--- a/tests/pytesseract_test.py
+++ b/tests/pytesseract_test.py
@@ -285,21 +285,24 @@ def test_run_and_get_multiple_output(test_file, function_mapping, extensions):
         (['pdf', 'txt'], '--dpi 300 --oem 3 --psm 6'),
     ],
 )
-def test_run_and_get_multiple_output_with_config(test_file, function_mapping, extensions, config):
+def test_run_and_get_multiple_output_with_config(
+    test_file, function_mapping, extensions, config,
+):
     compound_results = run_and_get_multiple_output(
-        test_file,
-        extensions=extensions,
-        config=config
+        test_file, extensions=extensions, config=config,
     )
     for result, extension in zip(compound_results, extensions):
         if extension == 'pdf':
             # pdf creation time could be different between the two so do not
             # check the whole string
             assert (
-                    result[:1000] == function_mapping[extension](test_file, config=config)[:1000]
+                result[:1000]
+                == function_mapping[extension](test_file, config=config)[:1000]
             )
         else:
-            assert result == function_mapping[extension](test_file, config=config)
+            assert result == function_mapping[extension](
+                test_file, config=config,
+            )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
This PR alters `run_and_get_multiple_output` to allow a `config` parameter, analogously to `run_and_get_output`, and append to it the string built for multiple outputs.

It also resolves #571 by:
- adding `-c` at the start of each extension's config string, allowing the list of extensions to have `box` in any order.
- adding `xml` to the set of extensions whose output should be read in bytes.

The original testing function now considers `xml` and includes an additional case for the problem with `box`, and a new test function is created for cases including a `config` string. With the changes to `run_and_get_multiple_output`, these tests pass.

I would appreciate feedback on the new test function, as I'm not sure if the test cases should include more significant or possibly problematic `config` strings, and whether it could be merged with the original test.